### PR TITLE
Fix downloader crash when wget fails or archive target is empty

### DIFF
--- a/archiver/index.js
+++ b/archiver/index.js
@@ -1,22 +1,91 @@
 var archiver = require('archiver');
 var fs = require('fs');
+var path = require('path');
 
+function emitError(io, data, err) {
+  console.error(err);
 
-module.exports= (file,io,data)=>{
+  if (io && data && data.token) {
+    io.emit(data.token, {
+      progress: 'Error: ' + err.message,
+      error: err.message
+    });
+  }
+}
 
-    var output = fs.createWriteStream("./public/sites/" +file+ '.zip');
-var archive = archiver('zip', {
-  zlib: { level: 9 } // Sets the compression level.
-});
+function assertSafeFolderName(file) {
+  if (typeof file !== 'string' || file.trim() === '') {
+    throw new Error('Downloaded folder name is missing.');
+  }
+
+  if (file === '.' || file === '..' || file.includes('/') || file.includes('\\')) {
+    throw new Error('Downloaded folder name is invalid.');
+  }
+
+  return file;
+}
+
+function buildArchivePaths(rootDir, file) {
+  var folderName = assertSafeFolderName(file);
+  var root = rootDir || process.cwd();
+
+  return {
+    folderName: folderName,
+    sourceDir: path.join(root, folderName),
+    outputDir: path.join(root, 'public', 'sites'),
+    zipPath: path.join(root, 'public', 'sites', folderName + '.zip')
+  };
+}
+
+function archiveSite(file,io,data){
+  var archivePaths;
+
+  try {
+    archivePaths = buildArchivePaths(process.cwd(), file);
+    if (!fs.existsSync(archivePaths.sourceDir)) {
+      throw new Error('Downloaded folder does not exist: ' + archivePaths.sourceDir);
+    }
+    fs.mkdirSync(archivePaths.outputDir, { recursive: true });
+  } catch (err) {
+    emitError(io, data, err);
+    return;
+  }
+
+  var output = fs.createWriteStream(archivePaths.zipPath);
+  var archive = archiver('zip', {
+    zlib: { level: 9 } // Sets the compression level.
+  });
+  var finished = false;
+
+  function fail(err) {
+    if (finished) {
+      return;
+    }
+
+    finished = true;
+    try {
+      archive.abort();
+    } catch (abortErr) {
+      // Ignore abort errors; the original archive error is the useful one.
+    }
+    emitError(io, data, err);
+  }
  
 // listen for all archive data to be written
 // 'close' event is fired only when a file descriptor is involved
 output.on('close', function() {
+  if (finished) {
+    return;
+  }
+
+  finished = true;
   console.log(archive.pointer() + ' total bytes');
   console.log('archiver has been finalized and the output file descriptor has closed.');
-  io.emit(data.token,{progress:"Completed",file})
+  io.emit(data.token,{progress:"Completed",file:archivePaths.folderName})
 
 });
+
+output.on('error', fail);
  
 // This event is fired when the data source is drained no matter what was the data source.
 // It is not part of this library but rather from the NodeJS Stream API.
@@ -27,17 +96,12 @@ output.on('end', function() {
  
 // good practice to catch warnings (ie stat failures and other non-blocking errors)
 archive.on('warning', function(err) {
-  if (err.code === 'ENOENT') {
-    // log warning
-  } else {
-    // throw error
-    throw err;
-  }
+  fail(err);
 });
  
 // good practice to catch this error explicitly
 archive.on('error', function(err) {
-  throw err;
+  fail(err);
 });
  
 // pipe archive data to the file
@@ -45,11 +109,20 @@ archive.pipe(output);
 
 // append files from a sub-directory and naming it `new-subdir` within the archive
 
-archive.directory('./'+file,false);
+archive.directory(archivePaths.sourceDir,false);
 
 // finalize the archive (ie we are done appending files but streams have to finish yet)
 // 'close', 'end' or 'finish' may be fired right after calling this method so register to them beforehand
-archive.finalize();
+var finalize = archive.finalize();
+if (finalize && typeof finalize.catch === 'function') {
+  finalize.catch(fail);
+}
 
  
 }
+
+archiveSite._internals = {
+  buildArchivePaths: buildArchivePaths
+};
+
+module.exports = archiveSite;

--- a/test/download-flow.test.js
+++ b/test/download-flow.test.js
@@ -1,0 +1,43 @@
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const archiveSite = require('../archiver');
+const downloadSite = require('../wget');
+
+test('parseDownloadRequest derives the wget output folder from the requested URL', () => {
+  const request = downloadSite._internals.parseDownloadRequest('https://example.com/docs/index.html');
+
+  assert.equal(request.url, 'https://example.com/docs/index.html');
+  assert.equal(request.folder, 'example.com');
+});
+
+test('parseDownloadRequest rejects URLs that wget should not run', () => {
+  assert.throws(
+    () => downloadSite._internals.parseDownloadRequest('ftp://example.com'),
+    /http or https/
+  );
+  assert.throws(
+    () => downloadSite._internals.parseDownloadRequest('not a url'),
+    /valid website URL/
+  );
+});
+
+test('buildArchivePaths refuses an empty downloaded folder name', () => {
+  const root = path.join(os.tmpdir(), 'zaixianwget-download-flow-test');
+
+  assert.throws(
+    () => archiveSite._internals.buildArchivePaths(root, ''),
+    /Downloaded folder name is missing/
+  );
+});
+
+test('buildArchivePaths writes zips under public/sites', () => {
+  const root = path.join(os.tmpdir(), 'zaixianwget-download-flow-test');
+  const paths = archiveSite._internals.buildArchivePaths(root, 'example.com');
+
+  assert.equal(paths.sourceDir, path.join(root, 'example.com'));
+  assert.equal(paths.outputDir, path.join(root, 'public', 'sites'));
+  assert.equal(paths.zipPath, path.join(root, 'public', 'sites', 'example.com.zip'));
+});

--- a/wget/index.js
+++ b/wget/index.js
@@ -1,9 +1,44 @@
-var util = require('util'),
-    exec = require('child_process').exec;
-    var archiver = require('../archiver')
+var spawn = require('child_process').spawn;
+var archiver = require('../archiver');
 
+function emitProgress(io, data, progress, error) {
+    if (!io || !data || !data.token) {
+        return;
+    }
 
-module.exports=(io,data)=>{
+    io.emit(data.token, {
+        progress: progress,
+        error: error ? error.message : undefined
+    });
+}
+
+function parseDownloadRequest(website) {
+    if (typeof website !== 'string' || website.trim() === '') {
+        throw new Error('Please enter a valid website URL.');
+    }
+
+    var parsed;
+    try {
+        parsed = new URL(website.trim());
+    } catch (err) {
+        throw new Error('Please enter a valid website URL.');
+    }
+
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        throw new Error('Website URL must use http or https.');
+    }
+
+    if (!parsed.host) {
+        throw new Error('Please enter a valid website URL.');
+    }
+
+    return {
+        url: parsed.toString(),
+        folder: parsed.host
+    };
+}
+
+function downloadWebsite(io, data) {
 
 // download all website assets 
 /**
@@ -15,22 +50,53 @@ module.exports=(io,data)=>{
  * --page-requisites – Download things like CSS style-sheets and images required to properly display the page offline.
  * --no-parent – When recurring do not ascend to the parent directory. It useful for restricting the download to only a portion of the site.
  */
-let website ="";
-const child = exec(`wget -mkEpnp --no-if-modified-since ${data.website}`);
+var request;
+try {
+    request = parseDownloadRequest(data && data.website);
+} catch (err) {
+    emitProgress(io, data, 'Error: ' + err.message, err);
+    return;
+}
+
+var child = spawn('wget', ['-mkEpnp', '--no-if-modified-since', request.url]);
+var spawnFailed = false;
 
 // read stdout from the current child.
-child.stderr.on("data",(response)=>{
+child.stderr.on("data",function(response){
 
-    if(response.startsWith("Resolving "))
-    {
-        website= response.substring(response.indexOf('Resolve ')+11,response.indexOf(' ('))
+    emitProgress(io, data, response.toString());
+});
+
+child.stdout.on("data",function(response){
+
+    emitProgress(io, data, response.toString());
+});
+
+child.on('error', function(err) {
+    spawnFailed = true;
+    emitProgress(io, data, 'Error: wget failed to start. Please install wget and try again.', err);
+});
+
+child.on('close',function(code, signal){
+    if (spawnFailed) {
+        return;
     }
-    io.emit(data.token,{progress:response})
-})
 
-child.stderr.on('close',(response)=>{
+    if (code !== 0) {
+        var message = signal
+            ? 'wget stopped with signal ' + signal + '.'
+            : 'wget exited with code ' + code + '.';
+        emitProgress(io, data, 'Error: ' + message, new Error(message));
+        return;
+    }
 
-    io.emit(data.token,{progress:"Converting"})
-    archiver(website,io,data)
-})
+    emitProgress(io, data, "Converting");
+    archiver(request.folder, io, data);
+});
 }
+
+downloadWebsite._internals = {
+    parseDownloadRequest: parseDownloadRequest
+};
+
+module.exports = downloadWebsite;


### PR DESCRIPTION
## Summary

修复网站下载流程中 `wget` 失败后仍继续压缩导致服务崩溃的问题。

## What Changed

- 校验用户输入的 URL，只允许 `http` / `https`
- 使用 `spawn` 执行 `wget`，避免 shell 拼接命令
- 当 `wget` 启动失败或退出码非 0 时，通过 socket 返回错误，不再继续进入压缩流程
- 压缩前校验下载目录名，避免生成 `public/sites/.zip`
- 自动创建 `public/sites` 输出目录
- 给 archive/output stream 增加错误处理，避免未捕获异常导致 Node 进程退出
- 增加回归测试覆盖 URL 解析和 archive 路径构造

## Bug

之前当 `wget` 不存在或下载失败时，`website` 变量为空，代码仍然调用 archiver，最终尝试写入：

```text
./public/sites/.zip
